### PR TITLE
Django/api treebanks

### DIFF
--- a/backend/gretel/settings.py
+++ b/backend/gretel/settings.py
@@ -37,14 +37,18 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',  # probably only relevant for local dev
     'treebanks',
     'search',
     'upload',
+    'rest_framework',
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    # probably only relevant for local dev
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -130,3 +134,5 @@ BASEX_HOST = 'localhost'
 BASEX_PORT = 1984
 BASEX_USER = 'admin'
 BASEX_PASSWORD = 'admin'
+
+CORS_ALLOWED_ORIGINS = ['http://localhost:4200', 'http://localhost']

--- a/backend/treebanks/serializers.py
+++ b/backend/treebanks/serializers.py
@@ -2,13 +2,13 @@ from .models import Treebank, Component
 from rest_framework import serializers
 
 
-class TreebankSerializer(serializers.HyperlinkedModelSerializer):
+class TreebankSerializer(serializers.ModelSerializer):
     class Meta:
         model = Treebank
         fields = ['slug', 'title', 'description', 'url_more_info']
 
 
-class ComponentSerializer(serializers.HyperlinkedModelSerializer):
+class ComponentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Component
-        fields = ['slug', 'title']
+        fields = ['slug', 'title', 'description', 'nr_sentences', 'nr_words']

--- a/backend/treebanks/serializers.py
+++ b/backend/treebanks/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 class TreebankSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Treebank
-        fields = ['slug', 'title']
+        fields = ['slug', 'title', 'description', 'url_more_info']
 
 
 class ComponentSerializer(serializers.HyperlinkedModelSerializer):

--- a/backend/treebanks/urls.py
+++ b/backend/treebanks/urls.py
@@ -2,8 +2,8 @@ from django.urls import include, path
 from .views import treebank_view, treebank_components_view
 
 urlpatterns = [
-    path('', treebank_view),
-    path('<slug:treebank>/components/', treebank_components_view),
+    path('treebank/', treebank_view),
+    path('treebank/<slug:treebank>/components/', treebank_components_view),
     path(
         'api-auth/',
         include('rest_framework.urls', namespace='rest_framework')

--- a/backend/treebanks/urls.py
+++ b/backend/treebanks/urls.py
@@ -1,16 +1,9 @@
 from django.urls import include, path
-from rest_framework import routers
-from .views import TreebankViewset, components_for_treebank_view
-
-router = routers.DefaultRouter()
-router.register(r'treebanks', TreebankViewset)
+from .views import treebank_view, treebank_components_view
 
 urlpatterns = [
-    path('', include(router.urls)),
-    path(
-        'components-for-treebank/<slug:treebank>',
-        components_for_treebank_view
-    ),
+    path('', treebank_view),
+    path('<slug:treebank>/components/', treebank_components_view),
     path(
         'api-auth/',
         include('rest_framework.urls', namespace='rest_framework')

--- a/backend/treebanks/urls.py
+++ b/backend/treebanks/urls.py
@@ -1,6 +1,6 @@
 from django.urls import include, path
 from rest_framework import routers
-from .views import TreebankViewset
+from .views import TreebankViewset, components_for_treebank_view
 
 router = routers.DefaultRouter()
 router.register(r'treebanks', TreebankViewset)
@@ -8,7 +8,11 @@ router.register(r'treebanks', TreebankViewset)
 urlpatterns = [
     path('', include(router.urls)),
     path(
+        'components-for-treebank/<slug:treebank>',
+        components_for_treebank_view
+    ),
+    path(
         'api-auth/',
         include('rest_framework.urls', namespace='rest_framework')
-    )
+    ),
 ]

--- a/backend/treebanks/views.py
+++ b/backend/treebanks/views.py
@@ -1,16 +1,23 @@
 from .models import Treebank, Component
 from .serializers import TreebankSerializer, ComponentSerializer
-from rest_framework import viewsets
+from rest_framework import viewsets, status
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
 
 
-class TreebankViewset(viewsets.ModelViewSet):
+class TreebankViewset(viewsets.ReadOnlyModelViewSet):
     # TODO: make sure that non-public treesets are hidden if needed
     queryset = Treebank.objects.all().order_by('slug')
     serializer_class = TreebankSerializer
 
 
-class ComponentViewset(viewsets.ModelViewSet):
-    # TODO: make sure that components of non-public treebanks are hidden if
-    # needed
-    queryset = Component.objects.all().order_by('slug')
-    serializer_class = ComponentSerializer
+@api_view(['GET'])
+def components_for_treebank_view(request, treebank):
+    try:
+        treebank = Treebank.objects.get(slug=treebank)
+        # TODO: test if treebank is public and if not if it is accessible
+    except Treebank.DoesNotExist:
+        return Response(None, status=status.HTTP_404_NOT_FOUND)
+    components = Component.objects.filter(treebank=treebank)
+    serializer = ComponentSerializer(components, many=True)
+    return Response(serializer.data)

--- a/backend/treebanks/views.py
+++ b/backend/treebanks/views.py
@@ -1,23 +1,25 @@
-from .models import Treebank, Component
+from .models import Treebank
 from .serializers import TreebankSerializer, ComponentSerializer
-from rest_framework import viewsets, status
+from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 
-class TreebankViewset(viewsets.ReadOnlyModelViewSet):
+@api_view(['GET'])
+def treebank_view(request):
     # TODO: make sure that non-public treesets are hidden if needed
-    queryset = Treebank.objects.all().order_by('slug')
-    serializer_class = TreebankSerializer
+    treebanks = Treebank.objects.all()
+    serializer = TreebankSerializer(treebanks, many=True)
+    return Response(serializer.data)
 
 
 @api_view(['GET'])
-def components_for_treebank_view(request, treebank):
+def treebank_components_view(request, treebank):
     try:
         treebank = Treebank.objects.get(slug=treebank)
         # TODO: test if treebank is public and if not if it is accessible
     except Treebank.DoesNotExist:
         return Response(None, status=status.HTTP_404_NOT_FOUND)
-    components = Component.objects.filter(treebank=treebank)
+    components = treebank.component_set
     serializer = ComponentSerializer(components, many=True)
     return Response(serializer.data)

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 Django>=4.0.0
 djangorestframework>=3.13.0
 alpino-query>=2.1.3
+django-cors-headers>=3.13.0
 BaseXClient

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,10 @@ basexclient==8.4.4
 django==4.0.6
     # via
     #   -r requirements.in
+    #   django-cors-headers
     #   djangorestframework
+django-cors-headers==3.13.0
+    # via -r requirements.in
 djangorestframework==3.13.1
     # via -r requirements.in
 lxml==4.7.1

--- a/web-ui/src/app/services/configuration.service.mock.ts
+++ b/web-ui/src/app/services/configuration.service.mock.ts
@@ -24,6 +24,10 @@ export class ConfigurationServiceMock implements ConfigurationServiceInterface {
         return '';
     }
 
+    async getDjangoUrl(path: string) {
+        return '/' + path;
+    }
+
     public async getProviders(): Promise<string[]> {
         return ['test-provider'];
     }

--- a/web-ui/src/app/services/configuration.service.ts
+++ b/web-ui/src/app/services/configuration.service.ts
@@ -38,6 +38,10 @@ export class ConfigurationService {
         return (await this.config).alpino + path;
     }
 
+    async getDjangoUrl(path: string) {
+        return (await this.config).django + path;
+    }
+
     async getProviders() {
         return Object.keys((await this.config).providers);
     }
@@ -63,4 +67,6 @@ interface Config {
     uploadUrl: string;
     /** Uploading requires a provider to request results */
     uploadProvider: string;
+
+    django: string;
 }

--- a/web-ui/src/app/services/treebank.service.ts
+++ b/web-ui/src/app/services/treebank.service.ts
@@ -408,7 +408,7 @@ export class TreebankService {
         // Not working with providers for now
 
         (async () => {
-            const djangoUrl = await this.configurationService.getDjangoUrl('treebanks/');
+            const djangoUrl = await this.configurationService.getDjangoUrl('treebanks/treebank/');
 
             this.http.get<DjangoTreebankResponse[]>(djangoUrl)
                 .pipe(
@@ -453,7 +453,7 @@ export class TreebankService {
                 metadata: async () => undefined,
                 componentGroups: async () => undefined,
                 components: async () => {
-                    const djangoComponents = await this.configurationService.getDjangoUrl('treebanks/' + bank.slug + '/components/')
+                    const djangoComponents = await this.configurationService.getDjangoUrl('treebanks/treebank/' + bank.slug + '/components/')
                         .then(url => this.http.get<DjangoComponentsForTreebankResponse[]>(url, {  }).toPromise());
                     
                     const components: TreebankComponent[] = djangoComponents.map(makeDjangoComponent);

--- a/web-ui/src/app/services/treebank.service.ts
+++ b/web-ui/src/app/services/treebank.service.ts
@@ -1,6 +1,5 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { async } from '@angular/core/testing';
 
 import { BehaviorSubject, Observable, ReplaySubject, merge, from, zip, EMPTY } from 'rxjs';
 import { flatMap, mergeMap, catchError, shareReplay, delay, map, first } from 'rxjs/operators';

--- a/web-ui/src/app/services/treebank.service.ts
+++ b/web-ui/src/app/services/treebank.service.ts
@@ -408,7 +408,7 @@ export class TreebankService {
         // Not working with providers for now
 
         (async () => {
-            const djangoUrl = await this.configurationService.getDjangoUrl('treebanks/treebanks/');
+            const djangoUrl = await this.configurationService.getDjangoUrl('treebanks/');
 
             this.http.get<DjangoTreebankResponse[]>(djangoUrl)
                 .pipe(
@@ -453,7 +453,7 @@ export class TreebankService {
                 metadata: async () => undefined,
                 componentGroups: async () => undefined,
                 components: async () => {
-                    const djangoComponents = await this.configurationService.getDjangoUrl('treebanks/components-for-treebank/' + bank.slug)
+                    const djangoComponents = await this.configurationService.getDjangoUrl('treebanks/' + bank.slug + '/components/')
                         .then(url => this.http.get<DjangoComponentsForTreebankResponse[]>(url, {  }).toPromise());
                     
                     const components: TreebankComponent[] = djangoComponents.map(makeDjangoComponent);

--- a/web-ui/src/assets/config/config.dev.json
+++ b/web-ui/src/assets/config/config.dev.json
@@ -1,8 +1,9 @@
 {
     "providers": {
-        "gretel": "/gretel/api/src/router.php/"
+        "gretel": "http://localhost/gretel/api/src/router.php/"
     },
     "alpino": "/gretel/api/src/router.php/",
-    "uploadUrl": "/gretel-upload/index.php/api/",
-    "uploadProvider": "gretel"
+    "uploadUrl": "http://localhost/gretel-upload/index.php/api/",
+    "uploadProvider": "gretel",
+    "django": "http://localhost:8000/"
 }

--- a/web-ui/src/assets/config/config.dev.json
+++ b/web-ui/src/assets/config/config.dev.json
@@ -1,9 +1,9 @@
 {
     "providers": {
-        "gretel": "http://localhost/gretel/api/src/router.php/"
+        "gretel": "/gretel/api/src/router.php/"
     },
     "alpino": "/gretel/api/src/router.php/",
-    "uploadUrl": "http://localhost/gretel-upload/index.php/api/",
+    "uploadUrl": "/gretel-upload/index.php/api/",
     "uploadProvider": "gretel",
-    "django": "http://localhost:8000/"
+    "django": "/"
 }


### PR DESCRIPTION
Retrieve treebank and component information from Django, modelled after the way GrETEL now interacts with gretel-upload. I have left the interaction with the two other APIs (gretel and gretel-upload) intact, making the results service very complex now, but eventually the two other APIs can be removed and the word Django can then be removed from function names like ``makeDjangoComponent``. I have copied the lines about CORS headers from the branch ``django/mwe-backend``.