### PR TITLE
Fix for duplicated results in MWE queries

### DIFF
--- a/backend/search/models.py
+++ b/backend/search/models.py
@@ -292,6 +292,10 @@ class SearchQuery(models.Model):
         all_matches: List[dict] = []
         counts = []
 
+        # In the following code we loop over `self.results` twice:
+        # 1. First we collect matches, and for that we would like to stop once
+        # the desired amount of matches is reached.
+
         if to_number is None or to_number > from_number:
             for result_obj in self.results.all().order_by('component'):
                 if not result_obj.search_completed:
@@ -310,6 +314,9 @@ class SearchQuery(models.Model):
                 if to_number is not None and len(all_matches) > to_number:
                     break
 
+        # 2. Here we collect statistics, and for that we would
+        # like to loop over the complete results set.
+
         for result_obj in self.results.all().order_by('component'):
             # Count completed part (for all results)
             if result_obj.completed_part is not None:
@@ -319,7 +326,7 @@ class SearchQuery(models.Model):
                 counts.append({
                     'component': result_obj.component.slug,
                     'number_of_results': result_obj.number_of_results,
-                    'completed': result_obj.search_completed,
+                    'completed': result_obj.search_completed is not None,
                     'percentage': percentage,
                 })
 

--- a/backend/search/models.py
+++ b/backend/search/models.py
@@ -6,11 +6,11 @@ from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
 from timeit import default_timer as timer
-import math
 import logging
 import pathlib
 import re
 from datetime import timedelta
+from typing import List
 
 from treebanks.models import Component
 from services.basex import basex
@@ -289,34 +289,28 @@ class SearchQuery(models.Model):
         a list of dictionaries and the percentage of search completion.
         This method saves the object to update last accessed time."""
         completed_part = 0
-        to_skip = from_number
-        if to_number is not None:
-            results_to_go = to_number - from_number
-        else:
-            results_to_go = math.inf
-        stop_adding = False
-        if to_number is not None and to_number <= from_number:
-            # Maximum number of results was already reached, so don't retrieve
-            # any results - but we still need to calculate the count and the
-            # search percentage.
-            stop_adding = True
-        all_matches = []
+        all_matches: List[dict] = []
         counts = []
+
+        if to_number is None or to_number > from_number:
+            for result_obj in self.results.all().order_by('component'):
+                if not result_obj.search_completed:
+                    # If result is empty or partially complete, stop adding.
+                    # There might still be results in later ComponentSearchResult-s,
+                    # but if we give them back already they will be returned in
+                    # the incorrect order and we would have to keep track of what
+                    # has already been returned and what not. We continue our loop
+                    # though, because we still want to know the count so far and
+                    # the search percentage.
+                    break
+
+                # Add matches to list
+                matches = result_obj.get_results()
+                all_matches.extend(matches)
+                if to_number is not None and len(all_matches) > to_number:
+                    break
+
         for result_obj in self.results.all().order_by('component'):
-            completed = True if result_obj.search_completed else False
-            # Add matches to list, as long as no empty or partial search result
-            # has been encountered.
-            if not (stop_adding or result_obj.number_of_results is None):
-                if to_skip >= result_obj.number_of_results:
-                    # Skip completely
-                    to_skip -= result_obj.number_of_results
-                else:
-                    matches = result_obj.get_results()
-                    all_matches.extend(matches[to_skip:])
-                    results_to_go -= len(matches) - to_skip
-                    to_skip = 0
-                    if results_to_go <= 0:
-                        stop_adding = True
             # Count completed part (for all results)
             if result_obj.completed_part is not None:
                 completed_part += result_obj.completed_part
@@ -325,31 +319,28 @@ class SearchQuery(models.Model):
                 counts.append({
                     'component': result_obj.component.slug,
                     'number_of_results': result_obj.number_of_results,
-                    'completed': completed,
+                    'completed': result_obj.search_completed,
                     'percentage': percentage,
                 })
-            # If result is empty or partially complete, stop adding.
-            # There might still be results in later ComponentSearchResult-s,
-            # but if we give them back already they will be returned in
-            # the incorrect order and we would have to keep track of what
-            # has already been returned and what not. We continue our loop
-            # though, because we still want to know the count so far and
-            # the search percentage.
-            if not completed:
-                stop_adding = True
+
         if self.total_database_size != 0:
             search_percentage = int(
                 100 * completed_part / self.total_database_size
             )
         else:
             search_percentage = 100
+
+        continue_from = len(all_matches)
+        # Skip results that were already returned
+        all_matches = all_matches[from_number:]
+
         # Check if too many results have been added
-        if results_to_go < 0:
-            to_remove = -results_to_go
-            all_matches = all_matches[0:-to_remove]
+        if to_number is not None:
+            all_matches = all_matches[0:to_number]
+
         self.last_accessed = timezone.now()
         self.save()
-        return (all_matches, search_percentage, counts)
+        return (all_matches, search_percentage, counts, continue_from)
 
     def perform_search(self) -> None:
         """Perform search and regularly update on progress"""

--- a/backend/search/tests.py
+++ b/backend/search/tests.py
@@ -245,7 +245,7 @@ class SearchQueryTestCase(TestCase):
             sq = SearchQuery(xpath=XPATH1)
             sq.save()
             sq.initialize()
-            results, percentage, _ = sq.get_results()
+            results, percentage, _, _ = sq.get_results()
             self.assertEqual(len(results), 0)
 
             # New SQ without any results
@@ -256,7 +256,7 @@ class SearchQueryTestCase(TestCase):
             components = test_treebank.components.all()
             sq2.components.add(*components)
             sq2.initialize()
-            results, percentage, _ = sq2.get_results()
+            results, percentage, _, _ = sq2.get_results()
             self.assertEqual(len(results), 0)
             self.assertEqual(percentage, 0)
 
@@ -265,15 +265,15 @@ class SearchQueryTestCase(TestCase):
             for csr in sq2.results.all():
                 csr.perform_search()
                 nr_results += csr.number_of_results
-            results, percentage, counts = sq2.get_results()
+            results, percentage, counts, _ = sq2.get_results()
             self.assertEqual(len(results), nr_results)
             self.assertEqual(percentage, 100)
 
             # Check if from_number and to_number work
             # (there should be seven results)
-            results2, _, _ = sq2.get_results(from_number=1)
+            results2, _, _, _ = sq2.get_results(from_number=1)
             self.assertEqual(results[1:], results2)
-            results3, _, _ = sq2.get_results(to_number=4)
+            results3, _, _, _ = sq2.get_results(to_number=4)
             self.assertEqual(results[:4], results3)
 
     def test_perform_search(self):

--- a/backend/search/views.py
+++ b/backend/search/views.py
@@ -207,7 +207,7 @@ def search_view(request):
             run_search_query.apply((query.pk,))
 
     # Get results so far, if any
-    results, percentage, counts = \
+    results, percentage, counts, continue_from = \
         query.get_results(start_from, maximum_results)
 
     if use_superset:
@@ -228,6 +228,7 @@ def search_view(request):
         'search_percentage': percentage,
         'results': results,
         'counts': counts,
+        'continue_from': continue_from
     }
     if percentage == 100:
         response['errors'] = query.get_errors()

--- a/web-ui/src/app/services/results.service.ts
+++ b/web-ui/src/app/services/results.service.ts
@@ -129,7 +129,6 @@ export class ResultsService {
                         if (results) {
                             observer.next(results);
                             queryId = results.queryId;
-                            // retrievedMatches += results.hits.length;
                             retrievedMatches = results.continueFrom;
 
                             // TODO maybe not the nicest way to show progress

--- a/web-ui/src/app/services/results.service.ts
+++ b/web-ui/src/app/services/results.service.ts
@@ -129,7 +129,8 @@ export class ResultsService {
                         if (results) {
                             observer.next(results);
                             queryId = results.queryId;
-                            retrievedMatches += results.hits.length;
+                            // retrievedMatches += results.hits.length;
+                            retrievedMatches = results.continueFrom;
 
                             // TODO maybe not the nicest way to show progress
                             const percentage = Math.round(results.searchPercentage)
@@ -403,6 +404,7 @@ export class ResultsService {
             errors: results.errors,
             cancelled: results.cancelled,
             counts: await this.mapCounts(results),
+            continueFrom: results.continue_from
         };
     }
 
@@ -581,6 +583,7 @@ type ApiSearchResult = {
         completed: boolean,
         percentage: number,
     }[],
+    continue_from: number,
 };
 
 /** Processed search results created from the response */
@@ -591,7 +594,7 @@ export interface SearchResults {
     errors: string;
     cancelled?: boolean;
     counts: ResultCount[];
-
+    continueFrom: number;
 }
 
 export interface Hit {


### PR DESCRIPTION
In MWE searches we use subset and exclusion queries to filter the initial set of results we get from BaseX (via a superset query).
This means that the number of results the frontend receives can no longer be used to slice the result set on the backend. To solve that, I let the frontend know where the next set of results should start via an extra `continue_from` argument.

@tijmenbaarda I've also tried to simplify the `get_results()` method, I hope I got it right.