### PR TITLE
Export to JSON command and safety prefix for imports

### DIFF
--- a/backend/treebanks/management/commands/export_to_json.py
+++ b/backend/treebanks/management/commands/export_to_json.py
@@ -1,0 +1,46 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from pathlib import Path
+import json
+
+from treebanks.models import Treebank
+
+
+class Command(BaseCommand):
+    help = 'Export treebank information to a JSON file that can be used to ' \
+           'copy treebanks to other GrETEL installations'
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            'treebank',
+            help='The slug of the treebank you want to export'
+        )
+        parser.add_argument(
+            '--outputfile',
+            help='The output JSON file to write to'
+        )
+
+    def handle(self, *args, **options):
+        treebank_slug = options['treebank']
+        try:
+            treebank = Treebank.objects.get(slug=treebank_slug)
+        except Treebank.DoesNotExist:
+            raise CommandError('Treebank {} does not exist.'
+                               .format(treebank_slug))
+        outputfilename = options['outputfile']
+        if not outputfilename:
+            outputfilename = treebank_slug + '.json'
+        outputfilepath = Path(outputfilename)
+        if outputfilepath.exists():
+            raise CommandError('The file {} already exists.'
+                               .format(outputfilename))
+        configuration = treebank.serialize()
+        try:
+            with open(outputfilename, 'w') as f:
+                json.dump(configuration, f, indent=4)
+        except OSError as e:
+            raise CommandError('Error opening file {} for writing: {}'
+                               .format(outputfilename, e))
+        self.stdout.write(self.style.SUCCESS(
+            'Export written to {}.'.format(outputfilename)
+        ))

--- a/backend/treebanks/tests.py
+++ b/backend/treebanks/tests.py
@@ -1,3 +1,24 @@
-# from django.test import TestCase
+from django.test import TestCase
 
-# Create your tests here.
+from .models import Treebank, Component, BaseXDB
+
+
+class TreebankTestCase(TestCase):
+    def test_serialize(self):
+        '''Test treebank serialization including serialization of its
+        children Component and BaseXDB objects'''
+        treebank = Treebank(slug='test', title='Test')
+        comp = Component(slug='testcomp1', title='Testcomp1',
+                         treebank=treebank)
+        comp.nr_sentences = 0
+        comp.nr_words = 0
+        db = BaseXDB(component=comp, dbname='TESTDB', size=0)
+        treebank.save()
+        comp.save()
+        db.save()
+        ser = treebank.serialize()
+        self.assertEqual(ser['slug'], 'test')
+        self.assertEqual(len(ser['components']), 1)
+        self.assertEqual(ser['components'][0]['slug'], 'testcomp1')
+        self.assertEqual(len(ser['components'][0]['databases']), 1)
+        self.assertEqual(ser['components'][0]['databases'][0], 'TESTDB')

--- a/backend/upload/management/commands/import-existing.py
+++ b/backend/upload/management/commands/import-existing.py
@@ -114,6 +114,7 @@ class Command(BaseCommand):
         # Optional treebank-wide fields that are stored in JSON
         self.treebank.variants = self.configuration.get('variants', '[]')
         self.treebank.groups = self.configuration.get('groups', '{}')
+        self.treebank.metadata = self.configuration.get('metadata', '{}')
 
         # Get all Component and BaseXDB objects
         component_objs = []

--- a/backend/upload/management/commands/upload-lassy.py
+++ b/backend/upload/management/commands/upload-lassy.py
@@ -20,10 +20,6 @@ def userinputyesno(prompt, default=False):
     else:
         default_view = ' [y/N]'
     sys.stderr.write(prompt + default_view + '\n')
-    global use_defaults
-    if use_defaults:
-        sys.stderr.write('Default answer given')
-        return default
     answer = input()
     if answer[:1].lower() == 'y':
         return True
@@ -193,7 +189,7 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING(
                 'Treebank {} already exists.'.format(treebank_slug)
             ))
-            if userinputyesno(
+            if self.use_defaults or userinputyesno(
                 'Delete existing treebank? This will also delete the '
                 'associated databases from BaseX.', True
             ):
@@ -216,7 +212,9 @@ class Command(BaseCommand):
                 '{} BaseX databases with prefix {} already exist.'
                 .format(len(current_dbs), treebank_name)
             ))
-            if userinputyesno('Delete them? (they may be overwritten!)', True):
+            if self.use_defaults or userinputyesno(
+                'Delete them? (they may be overwritten!)', True
+            ):
                 for db in current_dbs:
                     try:
                         basex.execute('DROP DB {}'.format(db))
@@ -252,8 +250,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.group_by = options['group_by']
         self.input_dir = options['input_dir']
-        global use_defaults
-        use_defaults = options['defaults']
+        self.use_defaults = options['defaults']
 
         # Load list of user-friendly components names, if given
         if options['components_names']:

--- a/backend/upload/management/commands/upload-lassy.py
+++ b/backend/upload/management/commands/upload-lassy.py
@@ -287,7 +287,7 @@ class Command(BaseCommand):
         # Use the directory name as the title of the treebank
         treebank_title = os.path.basename(self.input_dir)
         # Prefix for BaseX databases
-        treebank_db = 'LASSYGR_' + treebank_title.upper() + '_ID'
+        treebank_db = 'GRETEL5_' + treebank_title.upper() + '_ID'
 
         # Create treebank in database
         treebank_slug = slugify(treebank_title)

--- a/backend/upload/models.py
+++ b/backend/upload/models.py
@@ -308,8 +308,8 @@ class TreebankUpload(models.Model):
                 comp_obj.nr_sentences = nr_sentences
                 comp_obj.nr_words = nr_words
                 comp_obj.save()
-                dbname = (treebankslug + '_' + componentslug + '_' +
-                          str(db_sequence)).upper()
+                dbname = ('GRETEL5_' + treebankslug + '_' + componentslug +
+                          '_' + str(db_sequence)).upper()
                 basexdb_obj = BaseXDB(dbname)
                 basexdb_objs.append(basexdb_obj)
                 basexdb_obj.component = comp_obj


### PR DESCRIPTION
* Make sure that all import/upload scripts add a prefix "GRETEL5_" to all BaseX databases they create to prevent any possible overlap with existing databases that are in use by GrETEL 4
* Add an export to JSON management command (to be used in combination with the `import_existing` command) to facilitate exchange of treebanks between servers (closes #49)
* Add support in the import_lassy script for the TWNC filename scheme and a --defaults option (to make it noninteractive). This has already been tested on the acceptation server with large corpora.