### PR TITLE
use BaseXClient iter() instead of execute() for search queries

### DIFF
--- a/backend/search/models.py
+++ b/backend/search/models.py
@@ -120,8 +120,6 @@ class ComponentSearchResult(models.Model):
             did_break = False
             # Go through all BaseX databases
             for database in databases_with_size:
-                if cancelled:
-                    break
                 size = databases_with_size[database]
                 # Check how many results we can still add to the cache file,
                 # respecting the maximum number of results per component
@@ -170,6 +168,7 @@ class ComponentSearchResult(models.Model):
                 self.save()
                 if query_id is not None and self._was_query_cancelled(query_id):
                     cancelled = True
+                    break
         self.cache_size = self._get_cache_path(False).stat().st_size
         if not cancelled:
             self.search_completed = timezone.now()

--- a/backend/services/basex.py
+++ b/backend/services/basex.py
@@ -14,7 +14,8 @@ class BaseXService:
 
     def perform_query_iter(self, query):
         session = self.get_session()
-        return session.query(query).iter()
+        yield from session.query(query).iter()
+        session.close()
 
     def execute(self, command):
         """Open a session, execute a command, close the session

--- a/backend/services/basex.py
+++ b/backend/services/basex.py
@@ -12,6 +12,10 @@ class BaseXService:
         session.close()
         return response
 
+    def perform_query_iter(self, query):
+        session = self.get_session()
+        return session.query(query).iter()
+
     def execute(self, command):
         """Open a session, execute a command, close the session
         and return the result"""


### PR DESCRIPTION
This is more resilient against queries with too many results (see #60) and should in theory also perform better for normal queries.