### PR TITLE
removed 'save adjusted xpath' feature

### DIFF
--- a/backend/mwe/urls.py
+++ b/backend/mwe/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from rest_framework.routers import SimpleRouter
 
-from .views import CanonicalFormList, GenerateMweQueries, XPathQueryViewSet
+from .views import CanonicalFormList, GenerateMweQueries
 
 urlpatterns = [
     path('canonical', CanonicalFormList.as_view(), name='canonical'),
@@ -10,6 +10,5 @@ urlpatterns = [
 ]
 
 router = SimpleRouter()
-router.register('xpath', XPathQueryViewSet, basename='xpath')
 
 urlpatterns += router.urls  # type: ignore

--- a/backend/mwe/views.py
+++ b/backend/mwe/views.py
@@ -75,10 +75,3 @@ class GenerateMweQueries(APIView):
                 queries[query.rank - 1] = XPathQuerySerializer(query).data
 
         return Response(queries.values())
-
-
-class XPathQueryViewSet(ModelViewSet):
-    serializer_class = XPathQuerySerializer
-
-    def get_queryset(self):
-        return XPathQuery.objects.all()

--- a/web-ui/src/app/components/step/mwe-results/mwe-results.component.html
+++ b/web-ui/src/app/components/step/mwe-results/mwe-results.component.html
@@ -31,9 +31,6 @@
         <div class="block">
             <grt-results-xpath-editor [xpath]="xpath" (changeXpath)="changeXpath.emit($event)"></grt-results-xpath-editor>
         </div>
-        <div class="block">
-            <button *ngIf="canSaveQuery" class="button" (click)="saveQuery.emit()">Save adjusted XPath query</button>
-        </div>
     </div>
     <!-- DISTRIBUTION LIST -->
     <div class="column">

--- a/web-ui/src/app/components/step/mwe-results/mwe-results.component.ts
+++ b/web-ui/src/app/components/step/mwe-results/mwe-results.component.ts
@@ -58,9 +58,6 @@ export class MweResultsComponent extends ResultsComponent {
     }
 
     @Output()
-    public saveQuery = new EventEmitter();
-
-    @Output()
     public changeQuery = new EventEmitter<MweQuery>();
 
     @Input()

--- a/web-ui/src/app/pages/multi-word-expressions/multi-word-expressions.component.html
+++ b/web-ui/src/app/pages/multi-word-expressions/multi-word-expressions.component.html
@@ -32,7 +32,6 @@
 
         (changeValid)="setValid($event)"
         (changeXpath)="updateXPath($event)"
-        (saveQuery)="saveQuery()"
         (changeRetrieveContext)="updateRetrieveContext($event)"
         (changeFilterValues)="updateFilterValues($event)"
         (prev)="prev()"

--- a/web-ui/src/app/pages/multi-word-expressions/multi-word-expressions.component.html
+++ b/web-ui/src/app/pages/multi-word-expressions/multi-word-expressions.component.html
@@ -29,7 +29,6 @@
         [inputSentence]="globalState.inputSentence"
         [retrieveContext]="globalState.retrieveContext"
         [xpath]="globalState.xpath"
-        [canSaveQuery]="globalState.canonicalForm.id !== undefined"
 
         (changeValid)="setValid($event)"
         (changeXpath)="updateXPath($event)"

--- a/web-ui/src/app/pages/multi-word-expressions/multi-word-expressions.component.ts
+++ b/web-ui/src/app/pages/multi-word-expressions/multi-word-expressions.component.ts
@@ -138,19 +138,6 @@ export class MultiWordExpressionsComponent extends MultiStepPageDirective<MweSta
         this.updateXPath(query.xpath);
     }
 
-    async saveQuery() {
-        let query = this.globalState.currentQuery;
-        let response = await this.mweService.saveCustomQuery({
-            id: query.id,
-            description: query.description,
-            xpath: this.globalState.xpath,
-            rank: query.rank,
-            canonical: this.globalState.canonicalForm.id,
-        });
-
-        this.stateService.setState({currentQuery: response});
-    }
-
     updateRetrieveContext(retrieveContext: boolean) {
         this.stateService.setState({ retrieveContext });
     }

--- a/web-ui/src/app/services/mwe.service.ts
+++ b/web-ui/src/app/services/mwe.service.ts
@@ -51,11 +51,4 @@ export class MweService {
 
         return response;
     }
-
-    async saveCustomQuery(query: MweQuery) : Promise<MweQuery> {
-        if (query.id) {
-            return this.http.put<MweQuery>(await this.saveQueryUrl + query.id + '/', query).toPromise();
-        }
-        return this.http.post<MweQuery>(await this.saveQueryUrl, query).toPromise();
-    }
 }

--- a/web-ui/src/app/services/mwe.service.ts
+++ b/web-ui/src/app/services/mwe.service.ts
@@ -28,12 +28,10 @@ export type MweQuerySet = MweQuery[];
 export class MweService {
     canonicalMweUrl: Promise<string>;
     generateMweUrl: Promise<string>;
-    saveQueryUrl: Promise<string>;
 
     constructor(configurationService: ConfigurationService, private http: HttpClient, private parserService: ParserService) {
         this.canonicalMweUrl = configurationService.getDjangoUrl('mwe/canonical');
         this.generateMweUrl = configurationService.getDjangoUrl('mwe/generate');
-        this.saveQueryUrl = configurationService.getDjangoUrl('mwe/xpath/');
     }
 
     async getCanonical() : Promise<MweCanonicalForm[]> {


### PR DESCRIPTION
Closes #72 

This feature is incomplete and doesn't make much sense in its current form.
I left in the models and admin views, so that admins can still save adjusted queries if necessary.