### PR TITLE
Feature/partial results

### DIFF
--- a/backend/search/models.py
+++ b/backend/search/models.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
-from timeit import default_timer as timer
 from copy import deepcopy
 import logging
 import pathlib
@@ -109,8 +108,6 @@ class ComponentSearchResult(models.Model):
         self.errors = ''
         self.completed_part = 0
         self.number_of_results = 0
-        start_time = timer()
-        next_save_time = start_time + 1
         # Open cache file
         try:
             resultsfile = self._get_cache_path(True).open(mode='w')
@@ -319,16 +316,6 @@ class SearchQuery(models.Model):
 
         if to_number is None or to_number > from_number:
             for result_obj in self._component_results():
-                if not result_obj.search_completed:
-                    # If result is empty or partially complete, stop adding.
-                    # There might still be results in later ComponentSearchResult-s,
-                    # but if we give them back already they will be returned in
-                    # the incorrect order and we would have to keep track of what
-                    # has already been returned and what not. We continue our loop
-                    # though, because we still want to know the count so far and
-                    # the search percentage.
-                    break
-
                 # Add matches to list
                 matches = result_obj.get_results()
                 for filter_ in self.filters:

--- a/backend/search/models.py
+++ b/backend/search/models.py
@@ -305,8 +305,8 @@ class SearchQuery(models.Model):
         return len(list(matches))
 
     def get_results(self, max_results: Optional[int] = None, exclude: Optional[Set[str]] = None) -> Tuple[ResultSet, float, List]:
-        """Get results so far. Object should have been initialized with
-        initialize() method but search does not have to be started yet
+        """Get results so far, except for those whose ids are in `exclude`.
+        Object should have been initialized with initialize() method but search does not have to be started yet
         with perform_search() method. Return a tuple of the result as
         a list of dictionaries and the percentage of search completion.
         This method saves the object to update last accessed time."""

--- a/backend/search/models.py
+++ b/backend/search/models.py
@@ -10,7 +10,7 @@ import logging
 import pathlib
 import re
 from datetime import timedelta
-from typing import List, Tuple, Iterable, Optional
+from typing import List, Tuple, Iterable, Optional, Set
 from lxml import etree
 
 from treebanks.models import Component
@@ -304,7 +304,7 @@ class SearchQuery(models.Model):
             matches = filter_(matches)
         return len(list(matches))
 
-    def get_results(self, from_number: int = 0, to_number: Optional[int] = None) -> Tuple[ResultSet, float, List]:
+    def get_results(self, max_results: Optional[int] = None, exclude: Optional[Set[str]] = None) -> Tuple[ResultSet, float, List]:
         """Get results so far. Object should have been initialized with
         initialize() method but search does not have to be started yet
         with perform_search() method. Return a tuple of the result as
@@ -318,20 +318,23 @@ class SearchQuery(models.Model):
         # 1. First we collect matches, and for that we would like to stop once
         # the desired amount of matches is reached.
 
-        if to_number is None or to_number > from_number:
-            for result_obj in self._component_results():
-                # Add matches to list
-                matches = result_obj.get_results()
-                for filter_ in self.filters:
-                    matches = filter_(matches)
-                all_matches.extend(matches)
-                if to_number is not None and len(all_matches) > to_number:
-                    break
+        for result_obj in self._component_results():
+            matches = result_obj.get_results()
+            # exclude matches that were already returned
+            if exclude is not None:
+                matches = [m for m in matches if m.id not in exclude]
+
+            for filter_ in self.filters:
+                matches = filter_(matches)
+            all_matches.extend(matches)
+
+            if max_results is not None and len(all_matches) > max_results:
+                break
 
         # 2. Here we collect statistics, and for that we would
         # like to loop over the complete results set.
 
-        for result_obj in self.results.all().order_by('component'):
+        for result_obj in self._component_results():
             # Count completed part (for all results)
             if result_obj.completed_part is not None:
                 completed_part += result_obj.completed_part
@@ -351,12 +354,9 @@ class SearchQuery(models.Model):
         else:
             search_percentage = 100
 
-        # Skip results that were already returned
-        all_matches = all_matches[from_number:]
-
         # Check if too many results have been added
-        if to_number is not None:
-            all_matches = all_matches[0:to_number]
+        if max_results is not None:
+            all_matches = all_matches[0:max_results]
 
         self.last_accessed = timezone.now()
         self.save()

--- a/backend/search/tests.py
+++ b/backend/search/tests.py
@@ -267,12 +267,21 @@ class SearchQueryTestCase(TestCase):
             self.assertEqual(len(results), nr_results)
             self.assertEqual(percentage, 100)
 
-            # Check if from_number and to_number work
-            # (there should be seven results)
-            results2, _, _ = sq2.get_results(from_number=1)
-            self.assertEqual(results[1:], results2)
-            results3, _, _ = sq2.get_results(to_number=4)
-            self.assertEqual(results[:4], results3)
+            # The remainder of the test assumes that there are more than
+            # two results (seven in the current setup).
+            assert len(results) > 2
+
+            # Check if exclude parameter works
+            exclude_set = set([x.id for x in results][0:2])
+            results2, _, _ = sq2.get_results(exclude=exclude_set)
+            self.assertEqual(len(results2), len(results) - 2)
+            # Empty set
+            results3, _, _ = sq2.get_results(exclude=set())
+            self.assertEqual(len(results3), len(results))
+            # Full set
+            exclude_set = set([x.id for x in results])
+            results4, _, _ = sq2.get_results(exclude=exclude_set)
+            self.assertEqual(len(results4), 0)
 
     def test_perform_search(self):
         with self.settings(CACHING_DIR=test_cache_path):

--- a/backend/search/types.py
+++ b/backend/search/types.py
@@ -72,7 +72,7 @@ class Result:
         self._nexts = nexts
 
     @property
-    def id(self):
+    def id(self) -> str:
         return self._match.sentid
 
     def __eq__(self, other):

--- a/backend/search/types.py
+++ b/backend/search/types.py
@@ -71,6 +71,10 @@ class Result:
         self._prevs = prevs
         self._nexts = nexts
 
+    @property
+    def id(self):
+        return self._match.sentid
+
     def __eq__(self, other):
         # used for testing purposes
         return self._match == other._match

--- a/backend/search/views.py
+++ b/backend/search/views.py
@@ -210,8 +210,12 @@ def search_view(request):
             run_search_query.apply((query.pk,))
 
     # Get results so far, if any
-    results, percentage, counts = \
-        query.get_results(start_from, maximum_results)
+    session_key = f'returned_{query.pk}'
+    returned = set(request.session.get(session_key, []))
+    maximum_results = max(0, maximum_results - len(returned))
+    results, percentage, counts = query.get_results(maximum_results, exclude=returned)
+    returned |= set(r.id for r in results)
+    request.session[session_key] = list(returned)
 
     if data.get('retrieveContext'):
         results = query.augment_with_context(results)

--- a/backend/search/views.py
+++ b/backend/search/views.py
@@ -209,7 +209,9 @@ def search_view(request):
             # No connection with message broker - run synchronously
             run_search_query.apply((query.pk,))
 
-    # Get results so far, if any
+    # Get results so far, if any.
+    # We store the ids of returned results in the request session,
+    # in order to deduplicate results by id.
     session_key = f'returned_{query.pk}'
     returned = set(request.session.get(session_key, []))
     maximum_results = max(0, maximum_results - len(returned))


### PR DESCRIPTION
With this PR, results are returned before the first component is search through (fixed #73)

Saving the match ids in the session is somewhat of a hack, but it's going to be more robust than relying on a stable sorting of the results. My first approach would be to save that in the frontend, but I'm afraid that would require too many changes.